### PR TITLE
Fix broken image reference for Zookeeper docs

### DIFF
--- a/content/ZooKeeper/src/main/asciidoc/index_de.adoc
+++ b/content/ZooKeeper/src/main/asciidoc/index_de.adoc
@@ -50,7 +50,7 @@ ZooKeeper ist ein verteilter, hochverfügbarer, skalierbarer und strikt konsiste
 
 
 == Data Model
-image::data-model.png[]
+image::../resources/images/data-model.png[]
 
 
 == Data Model

--- a/content/ZooKeeper/src/main/asciidoc/index_en.adoc
+++ b/content/ZooKeeper/src/main/asciidoc/index_en.adoc
@@ -51,7 +51,7 @@ ZooKeeper is a distributed, highly available, scalable and strictly consistent h
 
 
 == Data Model
-image::data-model.png[]
+image::../resources/images/data-model.png[]
 
 
 == Data Model


### PR DESCRIPTION
This fixes the preview in Github - maybe it breaks the actual rendering? That would be counter-intuitive though.